### PR TITLE
fix(event-listener): call element cb after `didInsertElement`

### DIFF
--- a/addon/event-listener.ts
+++ b/addon/event-listener.ts
@@ -8,7 +8,7 @@ import hookDisposablesRunner from './hook-disposables-runner';
 import { assert } from '@ember/debug';
 import ANONYMOUS from './utils/anonymous-field';
 import EmberObject from '@ember/object';
-import { beforeMethod } from 'patch-method';
+import { afterMethod } from 'patch-method';
 import Component from '@ember/component';
 import { Constructor } from './utils/type-helpers';
 
@@ -31,7 +31,7 @@ export default decoratorWithRequiredParams(function(
     return {
       ...desc,
       finisher(Class: Constructor<EmberObject>) {
-        beforeMethod(
+        afterMethod(
           Class as Constructor<Component>,
           typeof Class.prototype.didInsertElement === 'function'
             ? 'didInsertElement'

--- a/tests/integration/event-listener-test.ts
+++ b/tests/integration/event-listener-test.ts
@@ -41,4 +41,38 @@ module('@eventListener', function(hooks) {
     // eslint-disable-next-line typescript/no-non-null-assertion
     await click(this.element.querySelector('#test-component')!);
   });
+
+  test('it calls the callback after `didInsertElement`', async function(assert) {
+    assert.expect(1);
+
+    let didCall = false;
+
+    class TestComponent extends Component {
+      didInsertElement() {
+        super.didInsertElement();
+
+        assert.notOk(
+          didCall,
+          'callback was not called before the body of `didInsertElement`'
+        );
+      }
+      @eventListener(
+        t => {
+          didCall = true;
+          return t.element;
+        },
+        'click',
+        {
+          once: true
+        }
+      )
+      foo(event: MouseEvent) {
+        assert.ok(event instanceof MouseEvent);
+      }
+    }
+
+    this.owner.register('component:test-component', TestComponent);
+
+    await render(hbs`{{test-component id='test-component'}}`);
+  });
 });


### PR DESCRIPTION
This allows users to perform initial setup work in `didInsertElement` to avoid re-doing it for every event listener.

#### Before

```ts
export default class InputUnitComponent extends GlimmerComponent {
  /**
   * Used in the template as `data-guid="{this.guid}"` to work around missing
   * element modifiers or `this.bounds`.
   */
  private guid = guidFor(this);

  @eventListener(t => document.querySelector(`[data-guid="${this.guid}"]`), 'focusin')
  focusIn(event: FocusEvent) {
    // ...
  }

  @eventListener(t => document.querySelector(`[data-guid="${this.guid}"]`), 'focusout')
  focusOut(event: FocusEvent) {
    // ...
  }
}
```

#### After

```ts
export default class InputUnitComponent extends GlimmerComponent {
  /**
   * Used in the template as `data-guid="{this.guid}"` to work around missing
   * element modifiers or `this.bounds`.
   */
  private guid = guidFor(this);

  /**
   * The `<div>` element.
   */
  private element: Element;

  didInsertElement() {
    super.didInsertElement();

    this.element = document.querySelector(`[data-guid="${this.guid}"]`);
  }

  @eventListener(t => t.element, 'focusin')
  focusIn(event: FocusEvent) {
    // ...
  }

  @eventListener(t => t.element, 'focusout')
  focusOut(event: FocusEvent) {
    // ...
  }
}
```